### PR TITLE
Change iframe for iOS compatibility

### DIFF
--- a/plotly_in_shiny.md
+++ b/plotly_in_shiny.md
@@ -77,10 +77,11 @@ shinyServer(function(input, output) {
                                            fileopt="overwrite", # Overwrite plot in Plotly's website
                                            auto_open=FALSE))
 
-    tags$iframe(src=res$response$url,
+    tags$object(tags$embed(
+                  src=res$response$url,
                   frameBorder="0",  # Some aesthetics
                   height=400,
-                  width=650)
+                  width=650))
  
   })
 })


### PR DESCRIPTION
Apple's webkit was changed ca. 2011 in a way that messes up the height of iframe elements.  While Shiny apps with plotly-ized plots in `tags$iframe`s render normally on desktops/laptops, those figures fail on iOS devices: the plots will constantly grow in height without any user input.  While it is amusing to watch, the app becomes unusable relatively quickly.  Using `tags$object(tags$embed(...))` to send to `renderUI` and then `htmlOutput` solves the problem (at least with my testing).